### PR TITLE
Add property and slow connection tests

### DIFF
--- a/edge_case_test.go
+++ b/edge_case_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"testing"
+	"testing/quick"
+	"time"
+)
+
+// TestMakeAzureRequestTimeout verifies that makeAzureRequest handles slow connections
+func TestMakeAzureRequestTimeout(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"value":[]}`))
+	}))
+	defer server.Close()
+
+	client := &AzureClient{
+		Config:     Config{AccessToken: "tok"},
+		HTTPClient: &http.Client{Timeout: 10 * time.Millisecond},
+	}
+
+	_, err := client.makeAzureRequest(server.URL)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+}
+
+// TestSpinnerStartStop ensures spinner can start and stop around a slow operation
+func TestSpinnerStartStop(t *testing.T) {
+	s := NewSpinner("testing")
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	s.Start()
+	time.Sleep(250 * time.Millisecond)
+	s.Stop()
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	if buf.Len() == 0 {
+		t.Error("expected spinner output")
+	}
+
+	if s.active {
+		t.Error("spinner should not be active after Stop")
+	}
+}
+
+// TestValidateConcurrencyQuickCheck performs fuzz-like validation of concurrency handling
+func TestValidateConcurrencyQuickCheck(t *testing.T) {
+	fn := func(n int) bool {
+		v := validateConcurrency(n)
+		if n < 1 {
+			return v == 1
+		}
+		return v == n
+	}
+	if err := quick.Check(fn, nil); err != nil {
+		t.Errorf("quick check failed: %v", err)
+	}
+}
+
+// TestCheckIfDefaultResourceGroupFuzz ensures stability of default detection for random strings
+func TestCheckIfDefaultResourceGroupFuzz(t *testing.T) {
+	fn := func(name string) bool {
+		r1 := checkIfDefaultResourceGroup(name)
+		r2 := checkIfDefaultResourceGroup(name)
+		return reflect.DeepEqual(r1, r2)
+	}
+	if err := quick.Check(fn, nil); err != nil {
+		t.Errorf("quick check failed: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- improve test coverage with fuzz-like quick checks
- add spinner lifecycle test
- verify timeout errors on slow connections

## Testing
- `go test ./...` *(fails: proxy.golang.org forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_687edad72c4c83318057d50d25c855ed