### PR TITLE
Add spinner and concurrency fuzz tests

### DIFF
--- a/rate_limit_fuzz_test.go
+++ b/rate_limit_fuzz_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"io"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fuzz-like test to ensure semaphore respects max concurrency with varied delays
+func TestRateLimitingFuzz(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+	for i := 0; i < 5; i++ { // multiple iterations with random parameters
+		rgCount := rand.Intn(5) + 5 // 5-9 resource groups
+		maxConc := rand.Intn(4) + 1 // 1-4 concurrency
+
+		resourceGroups := make([]ResourceGroup, rgCount)
+		for j := range resourceGroups {
+			resourceGroups[j] = ResourceGroup{Name: "rg" + strconv.Itoa(j)}
+		}
+
+		var concurrent int32
+		var maxObserved int32
+		mockClient := &MockHTTPClient{DoFunc: func(req *http.Request) (*http.Response, error) {
+			atomic.AddInt32(&concurrent, 1)
+			c := atomic.LoadInt32(&concurrent)
+			for {
+				m := atomic.LoadInt32(&maxObserved)
+				if c > m {
+					if atomic.CompareAndSwapInt32(&maxObserved, m, c) {
+						break
+					}
+				} else {
+					break
+				}
+			}
+			time.Sleep(time.Duration(rand.Intn(20)+5) * time.Millisecond)
+			atomic.AddInt32(&concurrent, -1)
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(`{"value":[]}`))}, nil
+		}}
+
+		client := &AzureClient{Config: Config{SubscriptionID: "x", AccessToken: "y", MaxConcurrency: maxConc, Porcelain: true}, HTTPClient: mockClient}
+		client.processResourceGroupsConcurrently(resourceGroups)
+
+		if int(maxObserved) > maxConc {
+			t.Fatalf("iteration %d: observed concurrency %d > limit %d", i, maxObserved, maxConc)
+		}
+	}
+}

--- a/spinner_test.go
+++ b/spinner_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSpinnerStartStop(t *testing.T) {
+	spinner := NewSpinner("testing spinner")
+
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	spinner.Start()
+	time.Sleep(250 * time.Millisecond)
+	spinner.Stop()
+
+	w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	output := buf.String()
+
+	if !strings.Contains(output, "testing spinner") {
+		t.Errorf("expected spinner message in output, got %q", output)
+	}
+
+	frames := []string{"|", "/", "-", "\\"}
+	foundFrame := false
+	for _, f := range frames {
+		if strings.Contains(output, f) {
+			foundFrame = true
+			break
+		}
+	}
+	if !foundFrame {
+		t.Errorf("expected spinner frames in output, got %q", output)
+	}
+}


### PR DESCRIPTION
## Summary
- add a test for Spinner start/stop output
- add fuzz-like rate limit test exercising random concurrency

## Testing
- `go test ./...` *(fails: forbidden fetching modules)*

------
https://chatgpt.com/codex/tasks/task_b_687ebfc8b9988331a5880e7f1b82052b