### PR TITLE
Improve spinner tests and rename fuzz functions

### DIFF
--- a/extra_fuzz_test.go
+++ b/extra_fuzz_test.go
@@ -10,9 +10,9 @@ import (
 	"time"
 )
 
-// TestSpinnerStartStopFuzz verifies spinner activation and termination.
-// RENAMED from TestSpinnerStartStop to avoid redeclaration error
-func TestSpinnerStartStopFuzz(t *testing.T) {
+// TestSpinnerLifecycle verifies spinner activation and proper shutdown.
+// Previously named TestSpinnerStartStopFuzz.
+func TestSpinnerLifecycle(t *testing.T) {
 	s := NewSpinner("testing")
 	if s.active {
 		t.Fatal("spinner should not be active initially")
@@ -91,10 +91,10 @@ func TestMakeAzureRequestTimeout(t *testing.T) {
 	}
 }
 
-// FuzzValidateConcurrencyFuzz ensures validateConcurrency never returns less than 1.
-// RENAMED from FuzzValidateConcurrency to avoid redeclaration error
-func FuzzValidateConcurrencyFuzz(f *testing.F) {
-	seeds := []int{0, -5, 1, 10}
+// FuzzValidateConcurrencyNeverBelowOne ensures validateConcurrency never
+// returns a value less than one. Previously named FuzzValidateConcurrencyFuzz.
+func FuzzValidateConcurrencyNeverBelowOne(f *testing.F) {
+	seeds := []int{-100, -5, 0, 1, 2, 5, 10, 50}
 	for _, s := range seeds {
 		f.Add(s)
 	}

--- a/extra_test.go
+++ b/extra_test.go
@@ -38,6 +38,22 @@ func TestSpinnerStartStop(t *testing.T) {
 	}
 }
 
+// TestNewSpinnerInitialState verifies that a new spinner starts inactive and
+// with the provided message.
+func TestNewSpinnerInitialState(t *testing.T) {
+	msg := "init message"
+	s := NewSpinner(msg)
+	if s.message != msg {
+		t.Errorf("expected message %q, got %q", msg, s.message)
+	}
+	if s.active {
+		t.Error("spinner should not be active upon creation")
+	}
+	if s.done == nil {
+		t.Error("spinner done channel not initialized")
+	}
+}
+
 // TestFetchResourceGroupsSlowConnection simulates slower HTTP responses
 func TestFetchResourceGroupsSlowConnection(t *testing.T) {
 	mockClient := &MockHTTPClient{


### PR DESCRIPTION
## Summary
- rename `TestSpinnerStartStopFuzz` -> `TestSpinnerLifecycle`
- rename `FuzzValidateConcurrencyFuzz` -> `FuzzValidateConcurrencyNeverBelowOne`
- add more fuzz seeds and new test `TestNewSpinnerInitialState`

## Testing
- `go test ./...`
- `go test -cover ./...`


------
https://chatgpt.com/codex/tasks/task_b_687f0dc23b74833180be109ed1c1b487